### PR TITLE
Filenames with dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ By default [`latexmk`](http://personal.psu.edu/jcc8/software/latexmk/) is used t
 If `latexmk` fails, the `custom toolchain` is utilised which by default sequentially runs the typical `pdflatex`>`bibtex`>`pdflatex`>`pdflatex` command chain:
 
 ```
-%TEX %ARG %DOC && %BIB %DOC && %TEX %ARG %DOC && %TEX %ARG %DOC
+%TEX %ARG %DOC.%EXT && %BIB %DOC && %TEX %ARG %DOC.%EXT && %TEX %ARG %DOC.%EXT
 ```
 Multiple commands should be separated by `&&`. Placeholders `%TEX`,`%ARG` and `%BIB` will be replaced by tools defined in the settings menu
 `%DOC` will be replaced by the [root LaTeX](root_file) filename (without extension), while `%EXT` gives the file extension

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -187,9 +187,9 @@ class Builder extends Disposable
       cmd = cmd.split('%ARG').join(args)
       cmd = cmd.split('%DOC').join(
         # get basename and strip file extensions
-        @escapeFileName(path.basename(@latex.mainFile).replace(/\.([^\/]*)$/, ''))
+        @escapeFileName(@latex.mainDoc[0])
       )
-      cmd = cmd.split('%EXT').join(path.basename(@latex.mainFile).match(/\.([^\/]*)$/)[1])
+      cmd = cmd.split('%EXT').join(@latex.mainDoc[1])
       @cmds.push cmd
 
   escapeFileName: (file) ->

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -26,7 +26,7 @@ module.exports =
                   and `%DOC` will be replaced by the main LaTeX file which \
                   is either automatically detected or manually set'
     type: 'string'
-    default: '%TEX %ARG %DOC && %BIB %DOC && %TEX %ARG %DOC && %TEX %ARG %DOC'
+    default: '%TEX %ARG %DOC.%EXT && %BIB %DOC && %TEX %ARG %DOC.%EXT && %TEX %ARG %DOC.%EXT'
   compiler:
     title: 'LaTeX compiler to use'
     order: 4

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -49,7 +49,17 @@ class Manager extends Disposable
         @latex.manager.config?.latex_ext?.indexOf(path.extname(name)) > -1
       return true
     return false
-
+    
+  getDocandExt: (fpath) ->
+    @latex.manager.loadLocalCfg()
+    extnames = ['.tex','.tikz']
+    # Check custom extensions first to handle stuff like `main.tex.tikz`
+    if @latex.manager.config?.latex_ext?
+      extnames = Array.from(new Set(@latex.manager.config.latex_ext.concat(extnames)));
+    for ext in extnames
+      if path.basename(fpath).endsWith(ext)
+        return [path.basename(fpath).replace(ext,''), ext.slice(1)]
+        
   findMain: (here) ->
     result = @findMainSequence(here)
     if result and !fs.existsSync(@latex.mainFile)
@@ -64,6 +74,7 @@ class Manager extends Disposable
         }])
       return false
     @latex.panel.view.update()
+    @latex.mainDoc = @getDocandExt(@latex.mainFile)
     return result
 
   refindMain: () ->
@@ -144,8 +155,8 @@ class Manager extends Disposable
   findPDF: ->
     if !@findMain()
       return false
-    # //some.path/to/mainFile.blah.tex -> //some.path/to/mainFile/mainFile.pdf
-    pdfPath = @latex.mainFile.replace(/\.([^\\|\/]*)$/, '.pdf')
+    # //some.path/tex/mainFile.rev1.tex -> /some.path/tex/mainFile.rev1.pdf
+    pdfPath = @latex.mainFile.replace(///#{@latex.mainDoc[1]}$///, 'pdf')
     @latex.logger.debuglog.info("""PDF path: #{pdfPath}""")
     return pdfPath
 

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -80,6 +80,7 @@ class Viewer extends Disposable
   openViewerNewWindow: ->
     pdfPath = @latex.manager.findPDF()
     if !fs.existsSync pdfPath
+      @latex.logger.debuglog.error("""#{pdfPath} Doesn't exist""")
       return
 
     if !@getUrl()


### PR DESCRIPTION
Follow up from #211 
@maxb2 could you give this a shot? It should be more robust, while maintaining some flexibility still.

The logic is to strip known extensions, (`.tex` and `.tikz` by default along with ones defined in the `latex_ext` key) 

This should allow for such cases:

| Filename | `%DOC` | `%EXT` | `latex_ext`
| :---         |     :---:      |          :---: | :---: | 
| `foobar.tex` | `foobar` |`tex` | |
| `foo.bar.tex` | `foo.bar` |`tex` | |
| `foo.bar.tikz` | `foo.bar` |`tikz` | |
| `foobar.tex.tikz` | `foobar` |`tex.tikz` | `['tex.tikz']` | 
| `foo.bar.tex.tikz` | `foo.bar` |`tex.tikz` | `['tex.tikz']`|

Should be noted that when using `latex_ext` it should be expected to go in and change the build toolchain arguments to include `%EXT`