### PR TITLE
Fixed #173

### DIFF
--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -51,6 +51,10 @@ class Manager extends Disposable
     return false
     
   getDocandExt: (fpath) ->
+    # If the LaTeX root file does not exist, no point in continuing
+    if fpath == undefined
+      return
+    
     @latex.manager.loadLocalCfg()
     extnames = ['.tex','.tikz']
     # Check custom extensions first to handle stuff like `main.tex.tikz`


### PR DESCRIPTION
If the LaTeX root file does not exist (was deleted) or is not valid (does not have `begin{document}`) then the file will be undefined. This undefined variable gets passed to Object.basename, which only accepts string arguments, hence causing a deprecation warning.

**Steps to reproduce the bug:**
 1. Save an empty file with the extension `.tex`.
 2. Open the file in Atom.
 3. Type in a backslash character `\`, observe the resulting deprecation warning.