### PR TITLE
Root Path improvements

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -68,6 +68,8 @@ module.exports =
     if atom.config.get('atom-latex.hide_panel')
       @latex.panel.hidePanel()
 
+    @latex.manager.findMain(false)
+
   deactivate: ->
     @latex?.dispose()
     @disposables.dispose()

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -60,9 +60,9 @@ class Manager extends Disposable
         return true
       catch err
         console.log err
-    else
+    else # Create new File
       filePath = path.join rootDir, '.latexcfg'
-      @config = JSON.stringify {"root": rootpath}
+      @config = {"root": rootpath}
       fs.writeFileSync filePath, JSON.stringify @config
       return true
     return false

--- a/lib/manager.coffee
+++ b/lib/manager.coffee
@@ -43,13 +43,37 @@ class Manager extends Disposable
         console.log err
     return false
 
+  writeLocalCfg: (rootpath) ->
+    if @lastCfgTime? and Date.now() - @lastCfgTime < 200 or\
+       !atom.workspace.getActiveTextEditor()?
+      return @config?
+    @lastCfgTime = Date.now()
+    rootDir = @rootDir()
+    return false if !rootDir?
+    if '.latexcfg' in fs.readdirSync rootDir
+      try
+        filePath = path.join rootDir, '.latexcfg'
+        fileContent = fs.readFileSync filePath, 'utf-8'
+        @config = JSON.parse fileContent
+        @config.root = rootpath
+        fs.writeFileSync filePath, JSON.stringify @config
+        return true
+      catch err
+        console.log err
+    else
+      filePath = path.join rootDir, '.latexcfg'
+      @config = JSON.stringify {"root": rootpath}
+      fs.writeFileSync filePath, JSON.stringify @config
+      return true
+    return false
+
   isTexFile: (name) ->
     @latex.manager.loadLocalCfg()
     if path.extname(name) in ['.tex','.tikz'] or \
         @latex.manager.config?.latex_ext?.indexOf(path.extname(name)) > -1
       return true
     return false
-    
+
   getDocandExt: (fpath) ->
     if !fpath
       @latex.logger.debuglog.info("Invalid tex path")
@@ -62,7 +86,7 @@ class Manager extends Disposable
     for ext in extnames
       if path.basename(fpath).endsWith(ext)
         return [path.basename(fpath).replace(ext,''), ext.slice(1)]
-        
+
   findMain: (here) ->
     result = @findMainSequence(here)
     if result and !fs.existsSync(@latex.mainFile)
@@ -85,6 +109,7 @@ class Manager extends Disposable
     input.onchange = (=>
       if input.files.length > 0
         @latex.mainFile = input.files[0].path
+        @writeLocalCfg input.files[0].path
       @latex.panel.view.update()
     )
     input.click()
@@ -234,7 +259,7 @@ class Manager extends Disposable
     findFiles = () =>
         @latex.texFiles = [ @latex.mainFile ]
         @latex.bibFiles = []
-        @findDependentFiles(@latex.mainFile)    
+        @findDependentFiles(@latex.mainFile)
     if @disable_watcher or @watchRoot()
       findFiles()
       if @disable_watcher
@@ -242,7 +267,7 @@ class Manager extends Disposable
     else if !@rootDir()?
       findFiles()
     return true
-    
+
   findDependentFiles: (file) ->
     content = fs.readFileSync file, 'utf-8'
     baseDir = path.dirname(@latex.mainFile)

--- a/lib/view/panel.js
+++ b/lib/view/panel.js
@@ -107,7 +107,7 @@ class PanelView {
     }
 
     let buttons =
-      <div id="atom-latex-controls">
+      <div id="atom-latex-controls" class="atom-latex-control">
         <ButtonView icon="play" tooltip="Build LaTeX" click={()=>this.latex.builder.build()}/>
         <ButtonView icon="search" tooltip="Preview PDF" click={()=>this.latex.viewer.openViewer()}/>
         <ButtonView icon="list-ul" tooltip={this.showLog?"Hide build log":"Show build log"} click={() => this.toggleLog()} dim={!this.showLog}/>

--- a/styles/atom-latex.less
+++ b/styles/atom-latex.less
@@ -28,6 +28,10 @@
   margin-right: 5px;
 }
 
+.atom-latex-control {
+  display: flex;
+}
+
 .atom-latex-control-icon {
   font-size: 18px !important;
   margin: 4px 10px;
@@ -44,7 +48,15 @@
 }
 
 #atom-latex-root-text {
+font-size: 12px;
   margin-left: -4px;
+  margin-right: 10px;
+  margin-top: auto;
+  margin-bottom: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
 }
 
 #atom-latex-panel-resizer {


### PR DESCRIPTION
- Automatically loading root path when opening a project
- Saving root path to .latexcfg when user is setting in manually
- Improved rendering of Latex panel

![image](https://user-images.githubusercontent.com/58851724/102907690-b5b06c80-4476-11eb-9c07-3bdd829cc5ab.png)
Slightly decreasing font-size

![image](https://user-images.githubusercontent.com/58851724/102907802-d678c200-4476-11eb-84f3-201bb0bc36fc.png)
Path is overflowing to the left when it is too long